### PR TITLE
Ensure sign-up flow logs users in after redeeming invites

### DIFF
--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -2,13 +2,14 @@
 
 import { FormEvent, useState } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { z } from 'zod';
 import { createBrowserSupabaseClient } from '@/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { AlertCircle, CheckCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 
 const schema = z.object({
   email: z.string().email(),
@@ -21,14 +22,13 @@ export function SignUpForm() {
   const [password, setPassword] = useState('');
   const [inviteCode, setInviteCode] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
-    setSuccess(null);
-
     const validation = schema.safeParse({ email, password, inviteCode });
     if (!validation.success) {
       setError(validation.error.issues[0]?.message ?? 'Invalid input');
@@ -59,29 +59,48 @@ export function SignUpForm() {
       return;
     }
 
-    // Step 3: redeem invite only if session + user exists
-    if (data.user && data.session) {
-      const redeemRes = await fetch('/api/invite/redeem', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: inviteCode, userId: data.user.id }),
-      });
-
-      if (!redeemRes.ok) {
-        const payload = await redeemRes.json().catch(() => ({}));
-        setError(payload.error ?? 'Failed to redeem invite code');
-        setLoading(false);
-        return; // don’t continue if redeem failed
-      }
-
-      // success: user is logged in already
-      setSuccess('Welcome, you are now logged in.');
-      // optionally: router.push('/dashboard');
-    } else {
-      setError('Sign up succeeded but no session was returned.');
+    if (!data.user) {
+      setError('Sign up succeeded but no user was returned.');
+      setLoading(false);
+      return;
     }
 
+    // Step 3: redeem invite
+    const redeemRes = await fetch('/api/invite/redeem', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: inviteCode, userId: data.user.id }),
+    });
+
+    if (!redeemRes.ok) {
+      const payload = await redeemRes.json().catch(() => ({}));
+      setError(payload.error ?? 'Failed to redeem invite code');
+      setLoading(false);
+      return; // don’t continue if redeem failed
+    }
+
+    // Step 4: ensure the user has an active session. Some projects require email confirmation,
+    // which means signUp may not return a session. If that happens, try to sign in directly.
+    if (!data.session) {
+      const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (signInError || !signInData.session) {
+        setError(signInError?.message ?? 'Account created but failed to log you in.');
+        setLoading(false);
+        return;
+      }
+    }
+
+    const redirectTo = searchParams.get('redirectTo');
+    const safeRedirect = redirectTo && redirectTo.startsWith('/') ? redirectTo : '/';
+
     setLoading(false);
+
+    router.replace(safeRedirect);
+    router.refresh();
   };
 
   return (
@@ -120,12 +139,6 @@ export function SignUpForm() {
             <div className="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               <AlertCircle className="h-4 w-4" />
               {error}
-            </div>
-          )}
-          {success && (
-            <div className="flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm text-primary">
-              <CheckCircle className="h-4 w-4" />
-              {success}
             </div>
           )}
           <Button type="submit" className="w-full" disabled={loading}>


### PR DESCRIPTION
## Summary
- validate invite codes, redeem them, and handle missing user data during sign-up
- fall back to a password sign-in when Supabase does not return a session and redirect new users to their requested page (defaulting to the landing page)

## Testing
- _Not run (not requested)_

------
https://chatgpt.com/codex/tasks/task_e_68dcc863e4808327a42a7594d99434b9