### PR TITLE
Enhance simulator analytics and entry diagnostics

### DIFF
--- a/lib/loot-tables/types.ts
+++ b/lib/loot-tables/types.ts
@@ -81,21 +81,31 @@ export const lootTableDefinitionSchema = z.object({
 
 export type LootTableDefinition = z.infer<typeof lootTableDefinitionSchema>;
 
+export interface SimulationTimelineEvent {
+  run: number;
+  globalRoll: number;
+  quantity: number;
+}
+
 export interface SimulationResultEntry {
   entryId: string;
   type: LootType;
-  totalDrops: number;
+  totalYield: number;
   minYield: number;
   maxYield: number;
   itemId: string;
   firstAppearedAt: number | null;
   probability: number;
   perRunAverage: number;
+  hits: number;
+  bundleHits: number;
+  timeline: SimulationTimelineEvent[];
 }
 
 export interface SimulationResult {
   runs: number;
   durationMs: number;
+  totalRolls: number;
   entries: SimulationResultEntry[];
 }
 


### PR DESCRIPTION
## Summary
- expand the simulator drawer into a tabbed overview/inspector layout with sorting, renamed Yielded column, and per-entry hit metrics
- add inspector visualizations for selected entries including timelines, probability share bars, and expected-frequency heat indicators
- extend simulation results with hit counts, bundle tracking, timeline snapshots, and total roll counts produced by the worker

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dcdb36dd148327ba8c96d21db34bc3