### PR TITLE
Split settings into account and item registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Key routes:
 - `/loot-tables` – Searchable index
 - `/loot-tables/[id]` – Three-pane editor shell with autosave, inspector, and simulation drawer placeholder
 - `/loot-tables/new` – Draft creator experience using hybrid autosave
-- `/settings` – Account preferences stub
+- `/account-settings` – Account details and invite management
+- `/item-registry` – Item registration and maintenance
 
 ## Styling & Components
 - Tailwind CSS + CSS variables for glassmorphism

--- a/app/account-settings/actions.ts
+++ b/app/account-settings/actions.ts
@@ -8,10 +8,6 @@ const inviteSchema = z.object({
   code: z.string().optional(),
 });
 
-const itemSchema = z.object({
-  id: z.string().min(1),
-});
-
 function generateCode(prefix: string) {
   const random = Math.random().toString(36).toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8);
   return `${prefix}-${random}`;
@@ -61,35 +57,4 @@ export async function createInviteCodeAction(formData: FormData) {
   }
 
   return { ok: true, code } as const;
-}
-
-export async function registerItemAction(formData: FormData) {
-  const parsed = itemSchema.safeParse({
-    id: formData.get('id'),
-  });
-  if (!parsed.success) {
-    return { ok: false, error: 'Item ID is required' } as const;
-  }
-
-  const supabase = createServerSupabaseClient();
-  const { data: auth } = await supabase.auth.getUser();
-  const userId = auth.user?.id ?? null;
-
-  if (!userId) {
-    return { ok: false, error: 'Not authenticated' } as const;
-  }
-
-  const { error } = await supabase.from('items').insert({
-    id: parsed.data.id,
-    name: parsed.data.id,
-    description: null,
-    tags: null,
-  });
-
-  if (error) {
-    console.error('Failed to register item', error);
-    return { ok: false, error: 'Unable to register item. Ensure the ID is unique.' } as const;
-  }
-
-  return { ok: true } as const;
 }

--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next';
+import { AccountSettings } from '@/components/settings/account-settings';
+import { createServerSupabaseClient } from '@/supabase/server';
+
+export const metadata: Metadata = {
+  title: 'Account Settings | BetterPvP Admin Console',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function AccountSettingsPage() {
+  const supabase = createServerSupabaseClient();
+  const [{ data: auth }, { data: invites }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.from('invite_codes').select('*').order('created_at', { ascending: false }),
+  ]);
+
+  return <AccountSettings user={auth.user} invites={invites ?? []} />;
+}

--- a/app/item-registry/actions.ts
+++ b/app/item-registry/actions.ts
@@ -1,0 +1,65 @@
+'use server';
+
+import { z } from 'zod';
+import { createServerSupabaseClient } from '@/supabase/server';
+
+const itemSchema = z.object({
+  id: z.string().min(1),
+});
+
+export async function registerItemAction(formData: FormData) {
+  const parsed = itemSchema.safeParse({
+    id: formData.get('id'),
+  });
+  if (!parsed.success) {
+    return { ok: false, error: 'Item ID is required' } as const;
+  }
+
+  const supabase = createServerSupabaseClient();
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id ?? null;
+
+  if (!userId) {
+    return { ok: false, error: 'Not authenticated' } as const;
+  }
+
+  const { error } = await supabase.from('items').insert({
+    id: parsed.data.id,
+    name: parsed.data.id,
+    description: null,
+    tags: null,
+  });
+
+  if (error) {
+    console.error('Failed to register item', error);
+    return { ok: false, error: 'Unable to register item. Ensure the ID is unique.' } as const;
+  }
+
+  return { ok: true } as const;
+}
+
+export async function deleteItemAction(formData: FormData) {
+  const parsed = itemSchema.safeParse({
+    id: formData.get('id'),
+  });
+  if (!parsed.success) {
+    return { ok: false, error: 'Item ID is required' } as const;
+  }
+
+  const supabase = createServerSupabaseClient();
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id ?? null;
+
+  if (!userId) {
+    return { ok: false, error: 'Not authenticated' } as const;
+  }
+
+  const { error } = await supabase.from('items').delete().eq('id', parsed.data.id);
+
+  if (error) {
+    console.error('Failed to delete item', error);
+    return { ok: false, error: 'Unable to remove item' } as const;
+  }
+
+  return { ok: true } as const;
+}

--- a/app/item-registry/page.tsx
+++ b/app/item-registry/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+import { ItemRegistry } from '@/components/settings/item-registry';
+import { createServerSupabaseClient } from '@/supabase/server';
+
+export const metadata: Metadata = {
+  title: 'Item Registry | BetterPvP Admin Console',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ItemRegistryPage() {
+  const supabase = createServerSupabaseClient();
+  const [{ data: auth }, { data: items }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.from('items').select('*').order('created_at', { ascending: false }),
+  ]);
+
+  if (!auth.user) {
+    return null;
+  }
+
+  return <ItemRegistry items={items ?? []} />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function HomePage() {
                 </Link>
               </Button>
               <Button variant="outline" size="lg" className="gap-2" asChild>
-                <Link href="/settings">View Settings</Link>
+                <Link href="/account-settings">View Account Settings</Link>
               </Button>
             </div>
           </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,26 +1,7 @@
-import { Metadata } from 'next';
-import { AccountSettings } from '@/components/settings/account-settings';
-import { createServerSupabaseClient } from '@/supabase/server';
-
-export const metadata: Metadata = {
-  title: 'Settings | BetterPvP Admin Console',
-};
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-export default async function SettingsPage() {
-  const supabase = createServerSupabaseClient();
-  const [{ data: auth }, { data: invites }, { data: items }] = await Promise.all([
-    supabase.auth.getUser(),
-    supabase.from('invite_codes').select('*').order('created_at', { ascending: false }),
-    supabase.from('items').select('*').order('created_at', { ascending: false }),
-  ]);
-
-  return (
-    <AccountSettings
-      user={auth.user}
-      invites={invites ?? []}
-      items={items ?? []}
-    />
-  );
+export default function SettingsPage() {
+  redirect('/account-settings');
 }

--- a/components/navigation/app-header.tsx
+++ b/components/navigation/app-header.tsx
@@ -52,7 +52,7 @@ export function AppHeader({ environment = 'development' }: AppHeaderProps) {
           {reduced ? 'Enable glass' : 'Reduce glass'}
         </Button>
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/settings">Account</Link>
+          <Link href="/account-settings">Account</Link>
         </Button>
         <Button variant="outline" size="sm" className="gap-2" onClick={handleSignOut} disabled={signingOut}>
           <LogOut className="h-4 w-4" />

--- a/components/navigation/nav-data.ts
+++ b/components/navigation/nav-data.ts
@@ -7,5 +7,6 @@ export interface NavItem {
 export const NAV_ITEMS: NavItem[] = [
   { href: '/', label: 'Home', icon: 'home' },
   { href: '/loot-tables', label: 'Loot Tables', icon: 'grid' },
-  { href: '/settings', label: 'Settings', icon: 'settings' },
+  { href: '/account-settings', label: 'Account Settings', icon: 'account' },
+  { href: '/item-registry', label: 'Item Registry', icon: 'package' },
 ];

--- a/components/navigation/nav-icon.tsx
+++ b/components/navigation/nav-icon.tsx
@@ -1,10 +1,12 @@
 import { cn } from '@/lib/utils';
-import { Home, Grid2x2, Settings, type LucideIcon } from 'lucide-react';
+import { Home, Grid2x2, Settings, UserCog, Package, type LucideIcon } from 'lucide-react';
 
 const ICON_MAP: Record<string, LucideIcon> = {
   home: Home,
   grid: Grid2x2,
   settings: Settings,
+  account: UserCog,
+  package: Package,
 };
 
 export function NavIcon({ name, className }: { name: string; className?: string }) {

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -10,15 +10,14 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import type { Database } from '@/supabase/types';
-import { createInviteCodeAction, registerItemAction } from '@/app/settings/actions';
+import { createInviteCodeAction } from '@/app/account-settings/actions';
 
 interface AccountSettingsProps {
   user: User | null;
   invites: Database['public']['Tables']['invite_codes']['Row'][];
-  items: Database['public']['Tables']['items']['Row'][];
 }
 
-export function AccountSettings({ user, invites, items }: AccountSettingsProps) {
+export function AccountSettings({ user, invites }: AccountSettingsProps) {
   const router = useRouter();
   const [displayName, setDisplayName] = useState(user?.user_metadata?.full_name ?? '');
   const [inviteRole, setInviteRole] = useState('admin');
@@ -26,10 +25,6 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
   const [inviteFeedback, setInviteFeedback] = useState<string | null>(null);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [creatingInvite, startCreateInvite] = useTransition();
-  const [itemId, setItemId] = useState('');
-  const [itemError, setItemError] = useState<string | null>(null);
-  const [itemFeedback, setItemFeedback] = useState<string | null>(null);
-  const [registeringItem, startRegisterItem] = useTransition();
 
   const handleInviteSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -54,30 +49,11 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
     });
   };
 
-  const handleRegisterItem = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setItemError(null);
-    setItemFeedback(null);
-    const formData = new FormData();
-    formData.append('id', itemId.trim());
-
-    startRegisterItem(async () => {
-      const response = await registerItemAction(formData);
-      if (response && !response.ok) {
-        setItemError(response.error ?? 'Unable to register item');
-        return;
-      }
-      setItemFeedback(`Item ${itemId.trim()} registered.`);
-      setItemId('');
-      router.refresh();
-    });
-  };
-
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-3xl font-semibold text-white">Settings</h1>
-        <p className="text-sm text-foreground/70">Manage your account, invite new admins, and register loot items.</p>
+        <p className="text-sm text-foreground/70">Manage your account information and invite new administrators.</p>
       </div>
       <Card>
         <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -176,65 +152,6 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
                     </td>
                     <td className="px-4 py-2 text-xs text-foreground/60">
                       {new Date(invite.created_at).toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ScrollArea>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <CardTitle>Registered items</CardTitle>
-            <CardDescription>Items listed here can be referenced by loot tables and simulations.</CardDescription>
-          </div>
-          <Badge variant="default">{items.length} items</Badge>
-        </CardHeader>
-        <CardContent className="grid gap-6 lg:grid-cols-[320px_1fr]">
-          <form className="space-y-4 rounded-2xl border border-white/10 bg-black/40 p-4" onSubmit={handleRegisterItem}>
-            <div className="space-y-2">
-              <Label htmlFor="item-id">Item ID</Label>
-              <Input
-                id="item-id"
-                value={itemId}
-                onChange={(event) => setItemId(event.target.value)}
-                placeholder="minecraft:diamond"
-                required
-              />
-              <p className="text-xs text-foreground/50">
-                Only the canonical item identifier is stored. Display metadata is resolved in-game.
-              </p>
-            </div>
-            <Button type="submit" disabled={registeringItem}>
-              {registeringItem ? 'Registering…' : 'Register item'}
-            </Button>
-            {itemError && <p className="text-sm text-destructive">{itemError}</p>}
-            {itemFeedback && <p className="text-sm text-primary">{itemFeedback}</p>}
-          </form>
-          <ScrollArea className="h-64 rounded-2xl border border-white/10 bg-black/30">
-            <table className="w-full text-sm text-foreground/80">
-              <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
-                <tr>
-                  <th className="px-4 py-2 text-left">ID</th>
-                  <th className="px-4 py-2 text-left">Registered</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.length === 0 && (
-                  <tr>
-                    <td className="px-4 py-4 text-center text-foreground/50" colSpan={2}>
-                      No items registered yet. Add at least one to start building loot tables.
-                    </td>
-                  </tr>
-                )}
-                {items.map((item) => (
-                  <tr key={item.id} className="border-b border-white/5">
-                    <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
-                    <td className="px-4 py-2 text-xs text-foreground/60">
-                      Added {new Date(item.created_at).toLocaleString()}
                     </td>
                   </tr>
                 ))}

--- a/components/settings/item-registry.tsx
+++ b/components/settings/item-registry.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { FormEvent, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { Database } from '@/supabase/types';
+import { registerItemAction, deleteItemAction } from '@/app/item-registry/actions';
+
+interface ItemRegistryProps {
+  items: Database['public']['Tables']['items']['Row'][];
+}
+
+export function ItemRegistry({ items }: ItemRegistryProps) {
+  const router = useRouter();
+  const [itemId, setItemId] = useState('');
+  const [itemError, setItemError] = useState<string | null>(null);
+  const [itemFeedback, setItemFeedback] = useState<string | null>(null);
+  const [registeringItem, startRegisterItem] = useTransition();
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
+  const [deletingItem, startDeleteItem] = useTransition();
+
+  const handleRegisterItem = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setItemError(null);
+    setItemFeedback(null);
+    const trimmedId = itemId.trim();
+    const formData = new FormData();
+    formData.append('id', trimmedId);
+
+    startRegisterItem(async () => {
+      const response = await registerItemAction(formData);
+      if (response && !response.ok) {
+        setItemError(response.error ?? 'Unable to register item');
+        return;
+      }
+      setItemFeedback(`Item ${trimmedId} registered.`);
+      setItemId('');
+      router.refresh();
+    });
+  };
+
+  const handleDeleteItem = (id: string) => {
+    setItemError(null);
+    setItemFeedback(null);
+    const formData = new FormData();
+    formData.append('id', id);
+    setDeletingItemId(id);
+
+    startDeleteItem(async () => {
+      const response = await deleteItemAction(formData);
+      if (response && !response.ok) {
+        setItemError(response.error ?? 'Unable to remove item');
+        setDeletingItemId(null);
+        return;
+      }
+      setItemFeedback(`Item ${id} removed.`);
+      setDeletingItemId(null);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-semibold text-white">Item Registry</h1>
+        <p className="text-sm text-foreground/70">
+          Register items that can be referenced by loot tables and remove entries that are no longer needed.
+        </p>
+      </div>
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Registered items</CardTitle>
+            <CardDescription>Items listed here can be referenced by loot tables and simulations.</CardDescription>
+          </div>
+          <Badge variant="default">{items.length} items</Badge>
+        </CardHeader>
+        <CardContent className="grid gap-6 lg:grid-cols-[320px_1fr]">
+          <form className="space-y-4 rounded-2xl border border-white/10 bg-black/40 p-4" onSubmit={handleRegisterItem}>
+            <div className="space-y-2">
+              <Label htmlFor="item-id">Item ID</Label>
+              <Input
+                id="item-id"
+                value={itemId}
+                onChange={(event) => setItemId(event.target.value)}
+                placeholder="minecraft:diamond"
+                required
+              />
+              <p className="text-xs text-foreground/50">
+                Only the canonical item identifier is stored. Display metadata is resolved in-game.
+              </p>
+            </div>
+            <Button type="submit" disabled={registeringItem}>
+              {registeringItem ? 'Registering…' : 'Register item'}
+            </Button>
+            {itemError && <p className="text-sm text-destructive">{itemError}</p>}
+            {itemFeedback && <p className="text-sm text-primary">{itemFeedback}</p>}
+          </form>
+          <ScrollArea className="h-64 rounded-2xl border border-white/10 bg-black/30">
+            <table className="w-full text-sm text-foreground/80">
+              <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
+                <tr>
+                  <th className="px-4 py-2 text-left">ID</th>
+                  <th className="px-4 py-2 text-left">Registered</th>
+                  <th className="px-4 py-2 text-left">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.length === 0 && (
+                  <tr>
+                    <td className="px-4 py-4 text-center text-foreground/50" colSpan={3}>
+                      No items registered yet. Add at least one to start building loot tables.
+                    </td>
+                  </tr>
+                )}
+                {items.map((item) => {
+                  const isDeleting = deletingItem && deletingItemId === item.id;
+                  return (
+                    <tr key={item.id} className="border-b border-white/5">
+                      <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
+                      <td className="px-4 py-2 text-xs text-foreground/60">
+                        Added {new Date(item.created_at).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-2">
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="sm"
+                          disabled={isDeleting}
+                          onClick={() => handleDeleteItem(item.id)}
+                        >
+                          {isDeleting ? 'Removing…' : 'Remove'}
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create dedicated Account Settings route that continues to handle account info and invite codes
- add Item Registry page that supports registering and deleting items
- update navigation, landing page, and legacy /settings route to point to the new destinations

## Testing
- npm run lint *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5966a3888327b7d8b04251eda3aa