### PR TITLE
Add item registry search and loot table item combobox

### DIFF
--- a/components/editor/loot-table-editor.tsx
+++ b/components/editor/loot-table-editor.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useTransition } from 'react';
 import Link from 'next/link';
-import { Copy, Download, Plus, Share2, Trash2, Upload, Wand2 } from 'lucide-react';
+import { ChevronsUpDown, Copy, Download, Plus, Share2, Trash2, Upload, Wand2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -48,6 +48,141 @@ type Notification = {
   message: string;
   type: 'success' | 'info' | 'error';
 };
+
+interface ItemComboboxProps {
+  items: Database['public']['Tables']['items']['Row'][];
+  value: string;
+  onSelect: (itemId: string) => void;
+  placeholder: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+function ItemCombobox({ items, value, onSelect, placeholder, disabled, className }: ItemComboboxProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.id === value) ?? null,
+    [items, value],
+  );
+
+  const filteredItems = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return items;
+    }
+    return items.filter((item) => {
+      const id = item.id.toLowerCase();
+      const name = (item.name ?? '').toLowerCase();
+      return id.includes(normalized) || name.includes(normalized);
+    });
+  }, [items, query]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current) {
+        return;
+      }
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      return;
+    }
+    const nextValue = selectedItem ? selectedItem.name ?? selectedItem.id : '';
+    setQuery(nextValue);
+    requestAnimationFrame(() => {
+      inputRef.current?.select();
+    });
+  }, [open, selectedItem]);
+
+  const handleSelect = (itemId: string) => {
+    onSelect(itemId);
+    setOpen(false);
+  };
+
+  return (
+    <div className={cn('relative', className)} ref={containerRef}>
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center justify-between rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 focus:ring-offset-slate-900',
+          disabled ? 'cursor-not-allowed opacity-50' : 'hover:border-primary/50 hover:bg-primary/10',
+        )}
+        onClick={() => {
+          if (!disabled) {
+            setOpen((prev) => !prev);
+          }
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={disabled}
+      >
+        <span className={selectedItem ? 'text-white' : 'text-foreground/60'}>
+          {selectedItem ? selectedItem.name ?? selectedItem.id : placeholder}
+        </span>
+        <ChevronsUpDown className="h-4 w-4 text-foreground/50" />
+      </button>
+      {open && (
+        <div className="absolute left-0 z-30 mt-2 w-full min-w-[16rem] rounded-xl border border-white/10 bg-slate-950/95 p-2 shadow-xl backdrop-blur">
+          <Input
+            autoFocus
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search items..."
+            className="mb-2"
+          />
+          <div className="max-h-60 space-y-1 overflow-y-auto">
+            {filteredItems.length === 0 ? (
+              <p className="px-2 py-4 text-sm text-foreground/60">No items match your search.</p>
+            ) : (
+              filteredItems.map((item) => {
+                const isSelected = item.id === value;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={cn(
+                      'flex w-full flex-col items-start rounded-lg px-3 py-2 text-left text-sm transition hover:bg-primary/10',
+                      isSelected ? 'bg-primary/20 text-white' : 'text-foreground',
+                    )}
+                    onClick={() => handleSelect(item.id)}
+                  >
+                    <span className="font-medium text-white">{item.name ?? item.id}</span>
+                    <span className="text-xs text-foreground/60">{item.id}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function LootTableEditor({ tableId, definition: initialDefinition, metadata, items }: LootTableEditorProps) {
   const router = useRouter();
@@ -787,22 +922,18 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                   </CardDescription>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <Select
+                  <ItemCombobox
+                    className="sm:w-64"
+                    items={availableGuaranteedItems}
                     value={selectedGuaranteedItemId}
-                    onValueChange={setSelectedGuaranteedItemId}
+                    onSelect={setSelectedGuaranteedItemId}
                     disabled={availableGuaranteedItems.length === 0}
-                  >
-                    <SelectTrigger className="sm:w-48">
-                      <SelectValue placeholder={availableGuaranteedItems.length === 0 ? "No available items" : "Select item"} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableGuaranteedItems.map((item) => (
-                        <SelectItem key={item.id} value={item.id}>
-                          {item.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    placeholder={
+                      availableGuaranteedItems.length === 0
+                        ? 'No available items'
+                        : 'Search or select item'
+                    }
+                  />
                   <Select
                     value={selectedGuaranteedType}
                     onValueChange={(value) => setSelectedGuaranteedType(value as LootEntry['type'])}
@@ -932,22 +1063,18 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                   </CardDescription>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <Select
+                  <ItemCombobox
+                    className="sm:w-64"
+                    items={availableWeightedItems}
                     value={selectedWeightedItemId}
-                    onValueChange={setSelectedWeightedItemId}
+                    onSelect={setSelectedWeightedItemId}
                     disabled={availableWeightedItems.length === 0}
-                  >
-                    <SelectTrigger className="sm:w-48">
-                      <SelectValue placeholder={availableWeightedItems.length === 0 ? "No available items" : "Select item"} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableWeightedItems.map((item) => (
-                        <SelectItem key={item.id} value={item.id}>
-                          {item.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    placeholder={
+                      availableWeightedItems.length === 0
+                        ? 'No available items'
+                        : 'Search or select item'
+                    }
+                  />
                   <Select
                     value={selectedWeightedType}
                     onValueChange={(value) => setSelectedWeightedType(value as LootEntry['type'])}

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useTransition, useState } from 'react';
+import { FormEvent, useMemo, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import type { User } from '@supabase/supabase-js';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,6 +30,19 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
   const [itemError, setItemError] = useState<string | null>(null);
   const [itemFeedback, setItemFeedback] = useState<string | null>(null);
   const [registeringItem, startRegisterItem] = useTransition();
+  const [itemSearch, setItemSearch] = useState('');
+
+  const filteredItems = useMemo(() => {
+    const query = itemSearch.trim().toLowerCase();
+    if (!query) {
+      return items;
+    }
+    return items.filter((item) => {
+      const id = item.id.toLowerCase();
+      const name = (item.name ?? '').toLowerCase();
+      return id.includes(query) || name.includes(query);
+    });
+  }, [itemSearch, items]);
 
   const handleInviteSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -214,33 +227,47 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
             {itemError && <p className="text-sm text-destructive">{itemError}</p>}
             {itemFeedback && <p className="text-sm text-primary">{itemFeedback}</p>}
           </form>
-          <ScrollArea className="h-64 rounded-2xl border border-white/10 bg-black/30">
-            <table className="w-full text-sm text-foreground/80">
-              <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
-                <tr>
-                  <th className="px-4 py-2 text-left">ID</th>
-                  <th className="px-4 py-2 text-left">Registered</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.length === 0 && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="item-search">Search</Label>
+              <Input
+                id="item-search"
+                value={itemSearch}
+                onChange={(event) => setItemSearch(event.target.value)}
+                placeholder="Search registered items..."
+              />
+            </div>
+            <ScrollArea className="min-h-[20rem] max-h-[32rem] rounded-2xl border border-white/10 bg-black/30">
+              <table className="w-full text-sm text-foreground/80">
+                <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
                   <tr>
-                    <td className="px-4 py-4 text-center text-foreground/50" colSpan={2}>
-                      No items registered yet. Add at least one to start building loot tables.
-                    </td>
+                    <th className="px-4 py-2 text-left">ID</th>
+                    <th className="px-4 py-2 text-left">Registered</th>
                   </tr>
-                )}
-                {items.map((item) => (
-                  <tr key={item.id} className="border-b border-white/5">
-                    <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
-                    <td className="px-4 py-2 text-xs text-foreground/60">
-                      Added {new Date(item.created_at).toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ScrollArea>
+                </thead>
+                <tbody>
+                  {filteredItems.length === 0 ? (
+                    <tr>
+                      <td className="px-4 py-4 text-center text-foreground/50" colSpan={2}>
+                        {items.length === 0
+                          ? 'No items registered yet. Add at least one to start building loot tables.'
+                          : 'No items match your search.'}
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredItems.map((item) => (
+                      <tr key={item.id} className="border-b border-white/5">
+                        <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
+                        <td className="px-4 py-2 text-xs text-foreground/60">
+                          Added {new Date(item.created_at).toLocaleString()}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </ScrollArea>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- expand the registered items panel with a taller scroll area and a search input to filter items
- add a reusable combobox that lets loot table editors search for items when adding guaranteed or weighted entries

## Testing
- npm run lint *(fails: Next.js prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5e95c9c48327a9c831be3edc60d6