### PR TITLE
Add search to item registry and loot table selectors

### DIFF
--- a/components/editor/loot-table-editor.tsx
+++ b/components/editor/loot-table-editor.tsx
@@ -61,6 +61,10 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
   const [selectedWeightedType, setSelectedWeightedType] = useState<LootEntry['type']>('dropped_item');
   const [selectedGuaranteedItemId, setSelectedGuaranteedItemId] = useState<string>('');
   const [selectedGuaranteedType, setSelectedGuaranteedType] = useState<LootEntry['type']>('given_item');
+  const [isGuaranteedPickerOpen, setIsGuaranteedPickerOpen] = useState(false);
+  const [guaranteedSearch, setGuaranteedSearch] = useState('');
+  const [isWeightedPickerOpen, setIsWeightedPickerOpen] = useState(false);
+  const [weightedSearch, setWeightedSearch] = useState('');
 
   const addNotification = (message: string, type: 'success' | 'info' | 'error' = 'info') => {
     const id = Math.random().toString(36).slice(2);
@@ -93,6 +97,28 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
     const takenIds = new Set(definition.guaranteed.map((entry) => entry.itemId));
     return items.filter((item) => !takenIds.has(item.id));
   }, [definition.guaranteed, items]);
+
+  const filteredGuaranteedItems = useMemo(() => {
+    const query = guaranteedSearch.trim().toLowerCase();
+    if (!query) {
+      return availableGuaranteedItems;
+    }
+    return availableGuaranteedItems.filter((item) => {
+      const haystack = `${item.name ?? ''} ${item.id} ${item.description ?? ''}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [availableGuaranteedItems, guaranteedSearch]);
+
+  const filteredWeightedItems = useMemo(() => {
+    const query = weightedSearch.trim().toLowerCase();
+    if (!query) {
+      return availableWeightedItems;
+    }
+    return availableWeightedItems.filter((item) => {
+      const haystack = `${item.name ?? ''} ${item.id} ${item.description ?? ''}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [availableWeightedItems, weightedSearch]);
 
   const autosave = useAutosave({
     key: `loot-table:${tableId}`,
@@ -788,6 +814,13 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Select
+                    open={isGuaranteedPickerOpen}
+                    onOpenChange={(open) => {
+                      setIsGuaranteedPickerOpen(open);
+                      if (!open) {
+                        setGuaranteedSearch('');
+                      }
+                    }}
                     value={selectedGuaranteedItemId}
                     onValueChange={setSelectedGuaranteedItemId}
                     disabled={availableGuaranteedItems.length === 0}
@@ -796,11 +829,28 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                       <SelectValue placeholder={availableGuaranteedItems.length === 0 ? "No available items" : "Select item"} />
                     </SelectTrigger>
                     <SelectContent>
-                      {availableGuaranteedItems.map((item) => (
-                        <SelectItem key={item.id} value={item.id}>
-                          {item.name}
-                        </SelectItem>
-                      ))}
+                      <div
+                        className="sticky top-0 z-10 bg-popover p-2"
+                        onPointerDown={(event) => event.stopPropagation()}
+                      >
+                        <Input
+                          autoFocus
+                          value={guaranteedSearch}
+                          onChange={(event) => setGuaranteedSearch(event.target.value)}
+                          placeholder="Search items..."
+                          className="h-8"
+                          onKeyDown={(event) => event.stopPropagation()}
+                        />
+                      </div>
+                      {filteredGuaranteedItems.length === 0 ? (
+                        <div className="px-3 py-2 text-sm text-foreground/60">No items found.</div>
+                      ) : (
+                        filteredGuaranteedItems.map((item) => (
+                          <SelectItem key={item.id} value={item.id}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      )}
                     </SelectContent>
                   </Select>
                   <Select
@@ -933,6 +983,13 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Select
+                    open={isWeightedPickerOpen}
+                    onOpenChange={(open) => {
+                      setIsWeightedPickerOpen(open);
+                      if (!open) {
+                        setWeightedSearch('');
+                      }
+                    }}
                     value={selectedWeightedItemId}
                     onValueChange={setSelectedWeightedItemId}
                     disabled={availableWeightedItems.length === 0}
@@ -941,11 +998,28 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                       <SelectValue placeholder={availableWeightedItems.length === 0 ? "No available items" : "Select item"} />
                     </SelectTrigger>
                     <SelectContent>
-                      {availableWeightedItems.map((item) => (
-                        <SelectItem key={item.id} value={item.id}>
-                          {item.name}
-                        </SelectItem>
-                      ))}
+                      <div
+                        className="sticky top-0 z-10 bg-popover p-2"
+                        onPointerDown={(event) => event.stopPropagation()}
+                      >
+                        <Input
+                          autoFocus
+                          value={weightedSearch}
+                          onChange={(event) => setWeightedSearch(event.target.value)}
+                          placeholder="Search items..."
+                          className="h-8"
+                          onKeyDown={(event) => event.stopPropagation()}
+                        />
+                      </div>
+                      {filteredWeightedItems.length === 0 ? (
+                        <div className="px-3 py-2 text-sm text-foreground/60">No items found.</div>
+                      ) : (
+                        filteredWeightedItems.map((item) => (
+                          <SelectItem key={item.id} value={item.id}>
+                            {item.name}
+                          </SelectItem>
+                        ))
+                      )}
                     </SelectContent>
                   </Select>
                   <Select

--- a/components/settings/account-settings.tsx
+++ b/components/settings/account-settings.tsx
@@ -30,6 +30,7 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
   const [itemError, setItemError] = useState<string | null>(null);
   const [itemFeedback, setItemFeedback] = useState<string | null>(null);
   const [registeringItem, startRegisterItem] = useTransition();
+  const [itemSearch, setItemSearch] = useState('');
 
   const handleInviteSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -72,6 +73,14 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
       router.refresh();
     });
   };
+
+  const filteredItems = itemSearch
+    ? items.filter((item) => {
+        const query = itemSearch.toLowerCase();
+        const haystack = `${item.id} ${item.name ?? ''} ${item.description ?? ''}`.toLowerCase();
+        return haystack.includes(query);
+      })
+    : items;
 
   return (
     <div className="space-y-8">
@@ -214,33 +223,46 @@ export function AccountSettings({ user, invites, items }: AccountSettingsProps) 
             {itemError && <p className="text-sm text-destructive">{itemError}</p>}
             {itemFeedback && <p className="text-sm text-primary">{itemFeedback}</p>}
           </form>
-          <ScrollArea className="h-64 rounded-2xl border border-white/10 bg-black/30">
-            <table className="w-full text-sm text-foreground/80">
-              <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
-                <tr>
-                  <th className="px-4 py-2 text-left">ID</th>
-                  <th className="px-4 py-2 text-left">Registered</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.length === 0 && (
+          <div className="space-y-4 rounded-2xl border border-white/10 bg-black/30 p-4">
+            <div className="space-y-2">
+              <Label htmlFor="item-search">Search registered items</Label>
+              <Input
+                id="item-search"
+                value={itemSearch}
+                onChange={(event) => setItemSearch(event.target.value)}
+                placeholder="Search by ID"
+              />
+            </div>
+            <ScrollArea className="h-96 rounded-xl border border-white/10 bg-black/20 lg:h-[32rem]">
+              <table className="w-full text-sm text-foreground/80">
+                <thead className="sticky top-0 bg-black/60 text-xs uppercase tracking-wide text-foreground/60">
                   <tr>
-                    <td className="px-4 py-4 text-center text-foreground/50" colSpan={2}>
-                      No items registered yet. Add at least one to start building loot tables.
-                    </td>
+                    <th className="px-4 py-2 text-left">ID</th>
+                    <th className="px-4 py-2 text-left">Registered</th>
                   </tr>
-                )}
-                {items.map((item) => (
-                  <tr key={item.id} className="border-b border-white/5">
-                    <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
-                    <td className="px-4 py-2 text-xs text-foreground/60">
-                      Added {new Date(item.created_at).toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ScrollArea>
+                </thead>
+                <tbody>
+                  {filteredItems.length === 0 && (
+                    <tr>
+                      <td className="px-4 py-4 text-center text-foreground/50" colSpan={2}>
+                        {items.length === 0
+                          ? 'No items registered yet. Add at least one to start building loot tables.'
+                          : 'No items match your search.'}
+                      </td>
+                    </tr>
+                  )}
+                  {filteredItems.map((item) => (
+                    <tr key={item.id} className="border-b border-white/5">
+                      <td className="px-4 py-2 font-mono text-xs">{item.id}</td>
+                      <td className="px-4 py-2 text-xs text-foreground/60">
+                        Added {new Date(item.created_at).toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollArea>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- expand the registered items panel with a taller scroll area and an inline search input so items are easier to browse
- add client-side filtering to the loot table guaranteed and weighted item pickers so items can be searched before adding them

## Testing
- not run (tests require project-specific configuration)

------
https://chatgpt.com/codex/tasks/task_e_68dd5e95c9c48327a9c831be3edc60d6