### PR TITLE
Implement pity rule deletion and enhance simulation insights

### DIFF
--- a/components/editor/loot-table-editor.tsx
+++ b/components/editor/loot-table-editor.tsx
@@ -805,6 +805,22 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                             onBlur={autosave.handleBlur}
                           />
                         </div>
+                        <div className="sm:col-span-3 flex justify-end pt-1">
+                          <Button
+                            type="button"
+                            variant="destructive"
+                            size="sm"
+                            className="w-full sm:w-auto"
+                            onClick={() =>
+                              setDefinition((prev) => ({
+                                ...prev,
+                                pityRules: prev.pityRules.filter((_, i) => i !== index),
+                              }))
+                            }
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" /> Remove rule
+                          </Button>
+                        </div>
                       </div>
                     ))}
                     <Button

--- a/lib/loot-tables/types.ts
+++ b/lib/loot-tables/types.ts
@@ -81,7 +81,7 @@ export const lootTableDefinitionSchema = z.object({
 
 export type LootTableDefinition = z.infer<typeof lootTableDefinitionSchema>;
 
-export type SimulationTimelineEventType = 'appeared' | 'rolled' | 'consumed';
+export type SimulationTimelineEventType = 'appeared' | 'rolled' | 'consumed' | 'granted';
 
 export interface SimulationTimelineEvent {
   rollIndex: number;
@@ -89,6 +89,8 @@ export interface SimulationTimelineEvent {
   type: SimulationTimelineEventType;
   quantity?: number;
 }
+
+export type SimulationResultEntrySource = 'weighted' | 'guaranteed';
 
 export interface SimulationResultEntry {
   entryId: string;
@@ -98,11 +100,13 @@ export interface SimulationResultEntry {
   maxYield: number;
   itemId: string;
   firstAppearedAt: number | null;
+  firstRunAppearance: number | null;
   probability: number;
   perRunAverage: number;
   rollHits: number;
   bundleHits: number;
   timeline: SimulationTimelineEvent[];
+  source: SimulationResultEntrySource;
 }
 
 export interface SimulationResult {


### PR DESCRIPTION
## Summary
- add an inline remove action for pity rules so individual entries can be deleted without changing strategies
- extend the simulation worker to respect pity weight adjustments, include guaranteed loot, and expose first-run data for timeline display
- update the simulation workspace to surface guaranteed drops, show first run appearance, and provide run/roll timeline toggles with improved legends

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dd750078208327a4529236ccd18432