### PR TITLE
Implement paginated item registry loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
+NEXT_PUBLIC_APP_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ supabase/.temp
 .env
 .env.local
 .env.production
+tsconfig.tsbuildinfo

--- a/app/item-registry/page.tsx
+++ b/app/item-registry/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { ItemRegistry } from '@/components/items/registry';
 import { createServerSupabaseClient } from '@/supabase/server';
+import { DEFAULT_ITEMS_PAGE_SIZE, fetchItemsPage } from '@/lib/items/queries';
 
 export const metadata: Metadata = {
   title: 'Item Registry | BetterPvP Admin Console',
@@ -10,7 +11,15 @@ export const dynamic = 'force-dynamic';
 
 export default async function ItemRegistryPage() {
   const supabase = createServerSupabaseClient();
-  const { data: items } = await supabase.from('items').select('*').order('created_at', { ascending: false });
 
-  return <ItemRegistry items={items ?? []} />;
+  try {
+    const { items, count } = await fetchItemsPage(supabase, { limit: DEFAULT_ITEMS_PAGE_SIZE });
+
+    return (
+      <ItemRegistry initialItems={items} initialTotalCount={count} pageSize={DEFAULT_ITEMS_PAGE_SIZE} />
+    );
+  } catch (error) {
+    console.error('Failed to load item registry', error);
+    return <ItemRegistry initialItems={[]} initialTotalCount={0} pageSize={DEFAULT_ITEMS_PAGE_SIZE} />;
+  }
 }

--- a/app/loot-tables/[id]/simulate/page.tsx
+++ b/app/loot-tables/[id]/simulate/page.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft } from 'lucide-react';
 import { createServerSupabaseClient } from '@/supabase/server';
 import { SimulationWorkspace } from '@/components/simulation/simulation-workspace';
 import { computeWeightTotals, lootTableDefinitionSchema } from '@/lib/loot-tables/types';
+import { fetchAllItems } from '@/lib/items/queries';
+import type { ItemRow } from '@/lib/items/queries';
 
 interface SimulationPageProps {
   params: { id: string };
@@ -55,7 +57,13 @@ export default async function LootTableSimulationPage({ params }: SimulationPage
         updated_at: table.updated_at,
       };
 
-  const { data: itemsData } = await supabase.from('items').select('*').order('name');
+  let itemsData: ItemRow[] = [];
+  try {
+    itemsData = await fetchAllItems(supabase, { orderBy: 'name', ascending: true });
+  } catch (itemsError) {
+    console.error('Failed to load items for simulation', itemsError);
+  }
+
   const { probabilities } = computeWeightTotals(definition.entries);
 
   return (
@@ -74,7 +82,7 @@ export default async function LootTableSimulationPage({ params }: SimulationPage
           <ArrowLeft className="h-4 w-4" /> Back to editor
         </Link>
       </div>
-      <SimulationWorkspace definition={definition} probabilities={probabilities} items={itemsData ?? []} />
+      <SimulationWorkspace definition={definition} probabilities={probabilities} items={itemsData} />
     </div>
   );
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -7,7 +7,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'border-white/10 bg-white/10 text-foreground',
-        info: 'border-primary/50 bg-primary/20 text-primary-foreground',
+        info: 'border-primary/50 bg-primary/20 text-foreground',
         destructive: 'border-destructive/40 bg-destructive/20 text-destructive-foreground',
         outline: 'border-white/20 bg-transparent text-foreground',
       },

--- a/lib/items/queries.ts
+++ b/lib/items/queries.ts
@@ -1,0 +1,88 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/supabase/types';
+
+export type ItemRow = Database['public']['Tables']['items']['Row'];
+
+export const DEFAULT_ITEMS_PAGE_SIZE = 100;
+
+export interface ItemsQueryOptions {
+  search?: string;
+  orderBy?: 'created_at' | 'name';
+  ascending?: boolean;
+}
+
+export interface ItemsPageOptions extends ItemsQueryOptions {
+  from?: number;
+  limit?: number;
+}
+
+export interface ItemsPageResult {
+  items: ItemRow[];
+  count: number;
+  from: number;
+  to: number;
+}
+
+function escapeForIlike(value: string) {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+export function createItemsQuery(
+  client: SupabaseClient<Database>,
+  { search, orderBy = 'created_at', ascending = false }: ItemsQueryOptions = {},
+) {
+  let query = client.from('items').select('*', { count: 'exact' }).order(orderBy, { ascending });
+
+  if (search && search.trim()) {
+    const normalized = escapeForIlike(search.trim());
+    query = query.or(`id.ilike.%${normalized}%,name.ilike.%${normalized}%`);
+  }
+
+  return query;
+}
+
+export async function fetchItemsPage(
+  client: SupabaseClient<Database>,
+  { from = 0, limit = DEFAULT_ITEMS_PAGE_SIZE, ...options }: ItemsPageOptions = {},
+): Promise<ItemsPageResult> {
+  const to = from + Math.max(limit, 1) - 1;
+  const { data, error, count } = await createItemsQuery(client, options).range(from, to);
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    items: data ?? [],
+    count: count ?? (data?.length ?? 0),
+    from,
+    to,
+  };
+}
+
+export async function fetchAllItems(
+  client: SupabaseClient<Database>,
+  options: ItemsQueryOptions = {},
+  pageSize: number = DEFAULT_ITEMS_PAGE_SIZE,
+): Promise<ItemRow[]> {
+  const items: ItemRow[] = [];
+  let from = 0;
+  let total: number | null = null;
+
+  while (total === null || from < total) {
+    const { items: pageItems, count } = await fetchItemsPage(client, { ...options, from, limit: pageSize });
+    items.push(...pageItems);
+
+    if (count != null) {
+      total = count;
+    }
+
+    if (pageItems.length === 0) {
+      break;
+    }
+
+    from += pageItems.length;
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- add shared item query helpers that support pagination and bulk fetching
- switch the item registry to a paginated supabase client with infinite scroll and search feedback
- update loot table pages to use the shared helpers and ignore the TypeScript build info file

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dd80a744d88327ad8a0e2c9aacee81