### PR TITLE
Add award strategy options to loot table editor

### DIFF
--- a/app/loot-tables/[id]/page.tsx
+++ b/app/loot-tables/[id]/page.tsx
@@ -43,6 +43,7 @@ export default async function LootTableEditorPage({ params }: LootTableEditorPag
         name: table.name,
         description: table.description ?? undefined,
         notes: '',
+        awardStrategy: { type: 'DEFAULT' } as const,
         replacementStrategy: 'UNSET' as const,
         rollStrategy: { type: 'CONSTANT', rolls: 1 } as const,
         weightDistribution: 'STATIC' as const,

--- a/app/loot-tables/[id]/simulate/page.tsx
+++ b/app/loot-tables/[id]/simulate/page.tsx
@@ -46,6 +46,7 @@ export default async function LootTableSimulationPage({ params }: SimulationPage
         name: table.name,
         description: table.description ?? undefined,
         notes: '',
+        awardStrategy: { type: 'DEFAULT' } as const,
         replacementStrategy: 'UNSET' as const,
         rollStrategy: { type: 'CONSTANT', rolls: 1 } as const,
         weightDistribution: 'STATIC' as const,

--- a/app/loot-tables/new/actions.ts
+++ b/app/loot-tables/new/actions.ts
@@ -35,6 +35,7 @@ export async function createLootTableAction(formData: FormData) {
     name: parsed.data.name,
     description: parsed.data.description ?? undefined,
     notes: '',
+    awardStrategy: { type: 'DEFAULT' },
     replacementStrategy: 'UNSET',
     rollStrategy: { type: 'CONSTANT', rolls: 1 },
     weightDistribution: 'STATIC',

--- a/app/loot-tables/page.tsx
+++ b/app/loot-tables/page.tsx
@@ -43,6 +43,7 @@ async function Content({ query }: { query: string }) {
               name: table.name,
               description: table.description ?? undefined,
               notes: '',
+              awardStrategy: { type: 'DEFAULT' },
               replacementStrategy: 'UNSET',
               rollStrategy: { type: 'CONSTANT', rolls: 1 },
               weightDistribution: 'STATIC',

--- a/lib/loot-tables/types.ts
+++ b/lib/loot-tables/types.ts
@@ -29,6 +29,32 @@ export const rollStrategySchema = z.discriminatedUnion('type', [
 
 export type RollStrategy = z.infer<typeof rollStrategySchema>;
 
+export const awardStrategyTypes = ['DEFAULT', 'LOOT_CHEST'] as const;
+export type AwardStrategyType = (typeof awardStrategyTypes)[number];
+
+export const lootChestTypes = ['BIG', 'SMALL', 'CUSTOM'] as const;
+export type LootChestType = (typeof lootChestTypes)[number];
+
+export const soundEffectSchema = z.object({
+  key: z.string().default(''),
+  pitch: z.number().nonnegative().default(1),
+  volume: z.number().nonnegative().default(1),
+});
+
+export const awardStrategySchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('DEFAULT') }),
+  z.object({
+    type: z.literal('LOOT_CHEST'),
+    chestType: z.enum(lootChestTypes).default('BIG'),
+    mythicMobName: z.string().default(''),
+    soundEffect: soundEffectSchema.default({ key: '', pitch: 1, volume: 1 }),
+    dropDelay: z.number().int().nonnegative().default(0),
+    dropInterval: z.number().int().nonnegative().default(0),
+  }),
+]);
+
+export type AwardStrategy = z.infer<typeof awardStrategySchema>;
+
 export const lootEntryBaseSchema = z.object({
   id: z.string(),
   type: z.enum(lootTypes),
@@ -68,6 +94,7 @@ export const lootTableDefinitionSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   notes: z.string().optional(),
+  awardStrategy: awardStrategySchema.default({ type: 'DEFAULT' }),
   replacementStrategy: z.enum(replacementStrategies).default('UNSET'),
   rollStrategy: rollStrategySchema,
   weightDistribution: z.enum(weightDistributionStrategies).default('STATIC'),


### PR DESCRIPTION
## Summary
- extend loot table schema with a configurable award strategy and defaults for new or legacy tables
- add editor controls to choose default or loot chest delivery, including custom chest metadata fields

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e02aa473b88327b876a3a0caf14bc1