### PR TITLE
Add loot table award strategy configuration

### DIFF
--- a/app/loot-tables/new/actions.ts
+++ b/app/loot-tables/new/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 import { z } from 'zod';
 import { createServerSupabaseClient } from '@/supabase/server';
-import { lootTableDefinitionSchema } from '@/lib/loot-tables/types';
+import { createDefaultAwardStrategy, lootTableDefinitionSchema } from '@/lib/loot-tables/types';
 
 const payloadSchema = z.object({
   name: z.string().min(1),
@@ -35,6 +35,7 @@ export async function createLootTableAction(formData: FormData) {
     name: parsed.data.name,
     description: parsed.data.description ?? undefined,
     notes: '',
+    awardStrategy: createDefaultAwardStrategy(),
     replacementStrategy: 'UNSET',
     rollStrategy: { type: 'CONSTANT', rolls: 1 },
     weightDistribution: 'STATIC',

--- a/lib/loot-tables/types.ts
+++ b/lib/loot-tables/types.ts
@@ -29,6 +29,55 @@ export const rollStrategySchema = z.discriminatedUnion('type', [
 
 export type RollStrategy = z.infer<typeof rollStrategySchema>;
 
+export const awardStrategyTypes = ['DEFAULT', 'LOOT_CHEST'] as const;
+export type AwardStrategyType = (typeof awardStrategyTypes)[number];
+
+export const lootChestTypes = ['BIG', 'SMALL', 'CUSTOM'] as const;
+export type LootChestType = (typeof lootChestTypes)[number];
+
+export const lootChestSoundEffectSchema = z.object({
+  key: z.string().default(''),
+  pitch: z.number().nonnegative().default(1),
+  volume: z.number().nonnegative().default(1),
+});
+
+export type LootChestSoundEffect = z.infer<typeof lootChestSoundEffectSchema>;
+
+export const createDefaultLootChestSoundEffect = (): LootChestSoundEffect => ({
+  key: '',
+  pitch: 1,
+  volume: 1,
+});
+
+export const lootChestCustomConfigSchema = z.object({
+  mythicMobName: z.string().default(''),
+  soundEffect: lootChestSoundEffectSchema.default(() => createDefaultLootChestSoundEffect()),
+  dropDelay: z.number().nonnegative().default(0),
+  dropInterval: z.number().nonnegative().default(0),
+});
+
+export type LootChestCustomConfig = z.infer<typeof lootChestCustomConfigSchema>;
+
+export const createDefaultLootChestCustomConfig = (): LootChestCustomConfig => ({
+  mythicMobName: '',
+  soundEffect: createDefaultLootChestSoundEffect(),
+  dropDelay: 0,
+  dropInterval: 0,
+});
+
+export const awardStrategySchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('DEFAULT') }),
+  z.object({
+    type: z.literal('LOOT_CHEST'),
+    chestType: z.enum(lootChestTypes).default('BIG'),
+    custom: lootChestCustomConfigSchema.default(() => createDefaultLootChestCustomConfig()),
+  }),
+]);
+
+export type AwardStrategy = z.infer<typeof awardStrategySchema>;
+
+export const createDefaultAwardStrategy = (): AwardStrategy => ({ type: 'DEFAULT' });
+
 export const lootEntryBaseSchema = z.object({
   id: z.string(),
   type: z.enum(lootTypes),
@@ -68,6 +117,7 @@ export const lootTableDefinitionSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   notes: z.string().optional(),
+  awardStrategy: awardStrategySchema.default(() => createDefaultAwardStrategy()),
   replacementStrategy: z.enum(replacementStrategies).default('UNSET'),
   rollStrategy: rollStrategySchema,
   weightDistribution: z.enum(weightDistributionStrategies).default('STATIC'),


### PR DESCRIPTION
## Summary
- extend the loot table schema with a configurable award strategy that supports default and loot chest delivery
- initialize new loot tables with the default award strategy metadata
- add editor controls for selecting the award strategy, configuring loot chest presets, and supplying custom MythicMobs chest details

## Testing
- npm run lint *(fails: Next.js prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68e02aa473b88327b876a3a0caf14bc1