### PR TITLE
Add award strategy configuration to loot tables

### DIFF
--- a/app/loot-tables/[id]/page.tsx
+++ b/app/loot-tables/[id]/page.tsx
@@ -48,6 +48,7 @@ export default async function LootTableEditorPage({ params }: LootTableEditorPag
         weightDistribution: 'STATIC' as const,
         pityRules: [],
         progressive: undefined,
+        awardStrategy: { type: 'DEFAULT' } as const,
         entries: [],
         guaranteed: [],
         version: table.version,

--- a/app/loot-tables/[id]/simulate/page.tsx
+++ b/app/loot-tables/[id]/simulate/page.tsx
@@ -46,6 +46,7 @@ export default async function LootTableSimulationPage({ params }: SimulationPage
         name: table.name,
         description: table.description ?? undefined,
         notes: '',
+        awardStrategy: { type: 'DEFAULT' } as const,
         replacementStrategy: 'UNSET' as const,
         rollStrategy: { type: 'CONSTANT', rolls: 1 } as const,
         weightDistribution: 'STATIC' as const,

--- a/app/loot-tables/new/actions.ts
+++ b/app/loot-tables/new/actions.ts
@@ -40,6 +40,7 @@ export async function createLootTableAction(formData: FormData) {
     weightDistribution: 'STATIC',
     pityRules: [],
     progressive: undefined,
+    awardStrategy: { type: 'DEFAULT' },
     entries: [],
     guaranteed: [],
     version: 1,

--- a/app/loot-tables/page.tsx
+++ b/app/loot-tables/page.tsx
@@ -43,6 +43,7 @@ async function Content({ query }: { query: string }) {
               name: table.name,
               description: table.description ?? undefined,
               notes: '',
+              awardStrategy: { type: 'DEFAULT' } as const,
               replacementStrategy: 'UNSET',
               rollStrategy: { type: 'CONSTANT', rolls: 1 },
               weightDistribution: 'STATIC',

--- a/components/editor/loot-table-editor.tsx
+++ b/components/editor/loot-table-editor.tsx
@@ -57,9 +57,9 @@ const awardStrategyLabelMap: Record<AwardStrategyState['type'], string> = {
 };
 
 const lootChestLabelMap: Record<LootChestOption, string> = {
-  BIG: 'Big loot chest',
-  SMALL: 'Small loot chest',
-  CUSTOM: 'Custom loot chest',
+  BIG: 'Big',
+  SMALL: 'Small',
+  CUSTOM: 'Custom',
 };
 
 function getReplacement(entry: LootEntry, fallback: ReplacementStrategy) {
@@ -699,6 +699,44 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                             onBlur={autosave.handleBlur}
                           />
                         </div>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          <div className="space-y-1">
+                            <Label htmlFor="custom-drop-delay">Drop delay (ticks)</Label>
+                            <Input
+                              id="custom-drop-delay"
+                              type="number"
+                              min={0}
+                              value={customAwardStrategy.dropDelay}
+                              onChange={(event) =>
+                                handleCustomLootChestChange(
+                                  'dropDelay',
+                                  Number.isNaN(Number(event.target.value))
+                                    ? 0
+                                    : Math.max(0, Math.floor(Number(event.target.value))),
+                                )
+                              }
+                              onBlur={autosave.handleBlur}
+                            />
+                          </div>
+                          <div className="space-y-1">
+                            <Label htmlFor="custom-drop-interval">Drop interval (ticks)</Label>
+                            <Input
+                              id="custom-drop-interval"
+                              type="number"
+                              min={0}
+                              value={customAwardStrategy.dropInterval}
+                              onChange={(event) =>
+                                handleCustomLootChestChange(
+                                  'dropInterval',
+                                  Number.isNaN(Number(event.target.value))
+                                    ? 0
+                                    : Math.max(0, Math.floor(Number(event.target.value))),
+                                )
+                              }
+                              onBlur={autosave.handleBlur}
+                            />
+                          </div>
+                        </div>
                         <div className="space-y-2">
                           <Label>Sound effect</Label>
                           <div className="grid gap-3 sm:grid-cols-3">
@@ -756,44 +794,6 @@ export function LootTableEditor({ tableId, definition: initialDefinition, metada
                                 onBlur={autosave.handleBlur}
                               />
                             </div>
-                          </div>
-                        </div>
-                        <div className="grid gap-3 sm:grid-cols-2">
-                          <div className="space-y-1">
-                            <Label htmlFor="custom-drop-delay">Drop delay (ticks)</Label>
-                            <Input
-                              id="custom-drop-delay"
-                              type="number"
-                              min={0}
-                              value={customAwardStrategy.dropDelay}
-                              onChange={(event) =>
-                                handleCustomLootChestChange(
-                                  'dropDelay',
-                                  Number.isNaN(Number(event.target.value))
-                                    ? 0
-                                    : Math.max(0, Math.floor(Number(event.target.value))),
-                                )
-                              }
-                              onBlur={autosave.handleBlur}
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label htmlFor="custom-drop-interval">Drop interval (ticks)</Label>
-                            <Input
-                              id="custom-drop-interval"
-                              type="number"
-                              min={0}
-                              value={customAwardStrategy.dropInterval}
-                              onChange={(event) =>
-                                handleCustomLootChestChange(
-                                  'dropInterval',
-                                  Number.isNaN(Number(event.target.value))
-                                    ? 0
-                                    : Math.max(0, Math.floor(Number(event.target.value))),
-                                )
-                              }
-                              onBlur={autosave.handleBlur}
-                            />
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- extend loot table definitions with a configurable award strategy including loot chest delivery metadata
- update the editor experience to toggle award strategies and edit custom loot chest fields
- ensure new tables and fallback definitions default to the standard award strategy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e02aa473b88327b876a3a0caf14bc1